### PR TITLE
Fix hanging during shutdown and logstash output

### DIFF
--- a/beat/execbeat.go
+++ b/beat/execbeat.go
@@ -5,6 +5,7 @@ import (
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher"
+	"time"
 )
 
 type Execbeat struct {
@@ -32,6 +33,7 @@ func (execBeat *Execbeat) Config(b *beat.Beat) error {
 
 func (execBeat *Execbeat) Setup(b *beat.Beat) error {
 	execBeat.events = b.Events
+	execBeat.done = make(chan struct{})
 
 	return nil
 }
@@ -47,7 +49,14 @@ func (execBeat *Execbeat) Run(b *beat.Beat) error {
 		go poller.Run()
 	}
 
+	ticker := time.NewTicker(3600 * time.Second)
+	defer ticker.Stop()
 	for {
+		select {
+			case <-execBeat.done:
+				return nil
+			case <-ticker.C:
+		}
 	}
 
 	return err

--- a/beat/execbeat.go
+++ b/beat/execbeat.go
@@ -36,14 +36,14 @@ func (execBeat *Execbeat) Setup(b *beat.Beat) error {
 	return nil
 }
 
-func (exexBeat *Execbeat) Run(b *beat.Beat) error {
+func (execBeat *Execbeat) Run(b *beat.Beat) error {
 	var err error
 
 	var poller *Executor
 
-	for i, exitConfig := range exexBeat.ExecConfig.Execbeat.Execs {
+	for i, exitConfig := range execBeat.ExecConfig.Execbeat.Execs {
 		logp.Debug("execbeat", "Creating poller # %v with command: %v", i, exitConfig.Command)
-		poller = NewExecutor(exexBeat, exitConfig)
+		poller = NewExecutor(execBeat, exitConfig)
 		go poller.Run()
 	}
 


### PR DESCRIPTION
I don't know go, so this is most likely not a *great* fix, but it fixes the issues I was having.

My test system is running Ubuntu 14.04 LTS, if that matters.

#### Symptom 1.

execbeat_console.yml
```YAML
execbeat:
  execs:
    -
      cron: "@every 5s"
      command: echo
      args: "hello"
      document_type: execbeat 

output:
   console:
```

```Shell
/usr/bin/execbeat -e -c execbeat_console.yml -d "publish"
```

Pressing ctrl+c gives:
```
^Cpanic: close of nil channel

goroutine 24 [running]:
github.com/christiangalsterer/execbeat/beat.(*Execbeat).Stop(0xc8200fe2d0)
	/home/ubuntu/go/src/github.com/christiangalsterer/execbeat/beat/execbeat.go:61 +0x24
```

#### Symptom 2.

Sometimes pressing ctrl+c does not close the process. It must be killed with `sudo kill -9 [pid]`

#### Symptom 3.

logstash.conf
```ruby
input {
    beats {
        port => 5044
    }
}

output {
    stdout {
        codec => rubydebug
    }
}
```
```
/opt/logstash/bin/logstash -f logstash.conf
```

execbeat_logstash.yml
```YAML
execbeat:
  execs:
    -
      cron: "@every 5s"
      command: echo
      args: "hello"
      document_type: execbeat 

output:
  logstash:
    hosts: ["localhost:5044"]
```
```
/usr/bin/execbeat -e -c execbeat_logstash.yml -d "publish"
```

execbeat hangs after the third publish. In this case it must always be killed with kill -9.

#### Explanation
I believe the infinite busy loop `for { }` in execbeat.go was only used to keep the main thread from exiting while `Executor` does its thing. I also believe it's the main culprit of the problems.

I examined topbeat and saw that it used a `Ticker` to schedule events and as a side effect, to keep the main thread running while waiting until it's time to trigger the next event.

For execbeat, we don't need to use `Ticker` to schedule events since that's handled by `Executor`, so with my fix we're merely using `Ticker`'s side effect of keeping the main thread running. This seems like a bit of a hack to me, but with no experience in go, I'm not sure what the recommended strategy is.

With my code changes in place, my manual testing shows that ctrl+c cleanly shuts down the program, and using logstash as an output no longer hangs after just a few publishes.